### PR TITLE
Watch only kubesquid configmap

### DIFF
--- a/ingress-supervisor/ConfigmapWatcher.cs
+++ b/ingress-supervisor/ConfigmapWatcher.cs
@@ -27,7 +27,7 @@ public class ConfigmapWatcher : BackgroundService
     }
     private async Task WatchConfigmaps()
     {
-        var configMapResp = _client.CoreV1.ListNamespacedConfigMapWithHttpMessagesAsync(_targetNamespace, watch: true);
+        var configMapResp = _client.CoreV1.ListNamespacedConfigMapWithHttpMessagesAsync(_targetNamespace, fieldSelector: "metadata.name=kubesquid", watch: true);
         Console.WriteLine("Starting to watch the config map");
         await foreach (var (type, configMap) in configMapResp.WatchAsync<V1ConfigMap, V1ConfigMapList>())
         {

--- a/ingress-supervisor/kubesquid-ingress-supervisor/templates/configmap.yaml
+++ b/ingress-supervisor/kubesquid-ingress-supervisor/templates/configmap.yaml
@@ -1,0 +1,5 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubesquid
+data: {}

--- a/ingress-supervisor/kubesquid-ingress-supervisor/templates/role.yaml
+++ b/ingress-supervisor/kubesquid-ingress-supervisor/templates/role.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: default
 rules:
   - apiGroups: ["*"]
+    resourceNames: ["kubesquid"]
     resources: ["configmaps"]
     verbs: ["watch", "get"]
 ---


### PR DESCRIPTION
Kubesquid is only allowed to watch the kubesquid CM which is part of the Helm chart.