### PR TITLE
Modify ingress

### DIFF
--- a/ingress-supervisor/ConfigmapWatcher.cs
+++ b/ingress-supervisor/ConfigmapWatcher.cs
@@ -47,7 +47,7 @@ public class ConfigmapWatcher : BackgroundService
                     var allIngresses = await _kubernetesWrapper.GetIngresses();
                     foreach (var serviceConfig in squidConfig)
                     {
-                        if (!_logic.ServiceHasIngress(allIngresses, serviceConfig))
+                        if (!_logic.ServiceHasMatchingIngress(allIngresses, serviceConfig))
                         {
                             await _kubernetesWrapper.CreateIngress(serviceConfig);
                         }

--- a/ingress-supervisor/ConfigmapWatcher.cs
+++ b/ingress-supervisor/ConfigmapWatcher.cs
@@ -55,7 +55,7 @@ public class ConfigmapWatcher : BackgroundService
 
                     foreach (var ingress in allIngresses)
                     {
-                        if (!_logic.IngressHasServiceConfig(ingress, squidConfig.ToList()))
+                        if (!_logic.IngressHasMatchingServiceConfig(ingress, squidConfig.ToList()))
                         {
                             await _kubernetesWrapper.DeleteIngress(ingress.Metadata.Name);
                         }

--- a/ingress-supervisor/KubernetesWrapper.cs
+++ b/ingress-supervisor/KubernetesWrapper.cs
@@ -97,7 +97,7 @@ public class KubernetesWrapper
 
         try
         {
-            var b = await _client.CreateNamespacedIngressAsync(ingress, _targetNamespace);
+            await _client.CreateNamespacedIngressAsync(ingress, _targetNamespace);
             _logger.LogInformation("Successfully created ingress: {}", ingress.Metadata.Name);
         }
         catch (Exception e)

--- a/ingress-supervisor/KubernetesWrapper.cs
+++ b/ingress-supervisor/KubernetesWrapper.cs
@@ -50,7 +50,7 @@ public class KubernetesWrapper
                 {"nginx.ingress.kubernetes.io/rewrite-target", "/$1"},
                 {"nginx.ingress.kubernetes.io/use-regex", "true"},
                 {
-                    $"nginx.ingress.kubernetes.io/configuration-snippet", @$"
+                    "nginx.ingress.kubernetes.io/configuration-snippet", @$"
                         proxy_set_header InstanceId {tenantConfig.InstanceId};
                     "
                 },

--- a/ingress-supervisor/KubernetesWrapper.cs
+++ b/ingress-supervisor/KubernetesWrapper.cs
@@ -92,11 +92,27 @@ public class KubernetesWrapper
             }
         };
 
-        var b = await _client.CreateNamespacedIngressAsync(ingress, _targetNamespace);
+        try
+        {
+            var b = await _client.CreateNamespacedIngressAsync(ingress, _targetNamespace);
+        }
+        catch (Exception e)
+        {
+           Console.WriteLine(e);
+        }
+
     }
 
     public async Task DeleteIngress(string ingressName)
     {
-        await _client.DeleteNamespacedIngressAsync(ingressName, _targetNamespace);
+        try
+        {
+            await _client.DeleteNamespacedIngressAsync(ingressName, _targetNamespace);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+        }
+
     }
 }

--- a/ingress-supervisor/Logic.cs
+++ b/ingress-supervisor/Logic.cs
@@ -12,7 +12,13 @@ public class Logic
         var matchingIngresses = ingresses
             .Where(ingress => "kubesquid".Equals(ingress.Metadata.Labels.GetOrDefault("app.kubernetes.io/created-by")))
             .Where(ingress => ingress.Spec.Rules.First().Host.Equals(serviceConfig.HostName))
-            .Where(ingress => ingress.Spec.Rules.First().Http.Paths.First().Path.Equals(serviceConfig.Path));
+            .Where(ingress => ingress.Spec.Rules.First().Http.Paths.First().Path.Equals(serviceConfig.Path))
+            .Where(ingress =>
+            {
+                if (!ingress.Metadata.Annotations.ContainsKey("nginx.ingress.kubernetes.io/configuration-snippet"))
+                    return false;
+                return ingress.Metadata.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"].Contains(serviceConfig.InstanceId);
+            });
         return matchingIngresses.Any();
     }
 

--- a/ingress-supervisor/Logic.cs
+++ b/ingress-supervisor/Logic.cs
@@ -7,6 +7,14 @@ namespace ingress_supervisor;
 public class Logic
 {
 
+    public bool ServiceHasMatchingIngress(IList<V1Ingress> ingresses, TenantConfig serviceConfig)
+    {
+        var matchingIngresses = ingresses
+            .Where(ingress => "kubesquid".Equals(ingress.Metadata.Labels.GetOrDefault("app.kubernetes.io/created-by")))
+            .Where(ingress => ingress.Spec.Rules.First().Host.Equals(serviceConfig.HostName));
+        return matchingIngresses.Any();
+    }
+
     public bool ServiceHasIngress(IList<V1Ingress> ingresses, TenantConfig serviceConfig)
     {
         if (!ingresses.Any())

--- a/ingress-supervisor/Logic.cs
+++ b/ingress-supervisor/Logic.cs
@@ -30,7 +30,9 @@ public class Logic
         }
 
         var matchingServiceConfigs = squidConfig
-            .Where(serviceConfig => serviceConfig.HostName.Equals(ingress.Spec.Rules.First().Host));
+            .Where(serviceConfig => serviceConfig.HostName.Equals(ingress.Spec.Rules.First().Host))
+            .Where(serviceConfig => serviceConfig.Path.Equals(ingress.Spec.Rules.First().Http.Paths.First().Path));
+
         return matchingServiceConfigs.Any();
     }
 }

--- a/ingress-supervisor/Logic.cs
+++ b/ingress-supervisor/Logic.cs
@@ -11,7 +11,8 @@ public class Logic
     {
         var matchingIngresses = ingresses
             .Where(ingress => "kubesquid".Equals(ingress.Metadata.Labels.GetOrDefault("app.kubernetes.io/created-by")))
-            .Where(ingress => ingress.Spec.Rules.First().Host.Equals(serviceConfig.HostName));
+            .Where(ingress => ingress.Spec.Rules.First().Host.Equals(serviceConfig.HostName))
+            .Where(ingress => ingress.Spec.Rules.First().Http.Paths.First().Path.Equals(serviceConfig.Path));
         return matchingIngresses.Any();
     }
 

--- a/ingress-supervisor/Logic.cs
+++ b/ingress-supervisor/Logic.cs
@@ -22,20 +22,7 @@ public class Logic
         return matchingIngresses.Any();
     }
 
-    public bool ServiceHasIngress(IList<V1Ingress> ingresses, TenantConfig serviceConfig)
-    {
-        if (!ingresses.Any())
-        {
-            return false;
-        }
-
-        var matchingIngresses = ingresses
-                .Where(ingress => "kubesquid".Equals(ingress.Metadata.Labels.GetOrDefault("app.kubernetes.io/created-by")))
-                .Where(ingress => ingress.Metadata.Name.Equals(serviceConfig.GetIngressName()));
-        return matchingIngresses.Any();
-    }
-
-    public bool IngressHasServiceConfig(V1Ingress ingress, IList<TenantConfig> squidConfig)
+    public bool IngressHasMatchingServiceConfig(V1Ingress ingress, IList<TenantConfig> squidConfig)
     {
         if (!"kubesquid".Equals(ingress.Metadata.Labels.GetOrDefault("app.kubernetes.io/created-by")))
         {
@@ -43,7 +30,7 @@ public class Logic
         }
 
         var matchingServiceConfigs = squidConfig
-            .Where(serviceConfig => serviceConfig.GetIngressName().Equals(ingress.Metadata.Name));
+            .Where(serviceConfig => serviceConfig.HostName.Equals(ingress.Spec.Rules.First().Host));
         return matchingServiceConfigs.Any();
     }
 }

--- a/ingress-supervisor/Logic.cs
+++ b/ingress-supervisor/Logic.cs
@@ -31,7 +31,13 @@ public class Logic
 
         var matchingServiceConfigs = squidConfig
             .Where(serviceConfig => serviceConfig.HostName.Equals(ingress.Spec.Rules.First().Host))
-            .Where(serviceConfig => serviceConfig.Path.Equals(ingress.Spec.Rules.First().Http.Paths.First().Path));
+            .Where(serviceConfig => serviceConfig.Path.Equals(ingress.Spec.Rules.First().Http.Paths.First().Path))
+            .Where(serviceConfig =>
+            {
+                if (!ingress.Metadata.Annotations.ContainsKey("nginx.ingress.kubernetes.io/configuration-snippet"))
+                    return false;
+                return ingress.Metadata.Annotations["nginx.ingress.kubernetes.io/configuration-snippet"].Contains(serviceConfig.InstanceId);
+            });
 
         return matchingServiceConfigs.Any();
     }

--- a/ingress-supervisor/Models/TenantConfig.cs
+++ b/ingress-supervisor/Models/TenantConfig.cs
@@ -16,7 +16,7 @@ public class TenantConfig
 
     public string Path { get; set; }
 
-    public string GetIngressName() => $"{ServiceName}-{InstanceId}-ingress";
+    public string GetIngressName() => $"{ServiceName}-{InstanceId}-ingress-{Guid.NewGuid().ToString("n").Substring(0, 8)}";
 
     public override string ToString()
     {

--- a/ingress-supervisor/Models/TenantConfig.cs
+++ b/ingress-supervisor/Models/TenantConfig.cs
@@ -7,7 +7,7 @@ namespace ingress_supervisor.Models;
 
 public class TenantConfig
 {
-    private const int IngressNameMaxLength = 253;
+    public const int IngressNameMaxLength = 253;
     public string ServiceName { get; set; }
 
     public string InstanceId { get; set; }
@@ -22,9 +22,10 @@ public class TenantConfig
     public string GetIngressName()
     {
         var source = Encoding.ASCII.GetBytes($"{ServiceName}{InstanceId}{HostName}{Port}{Path}");
-        var hash = BitConverter.ToString(SHA256.Create().ComputeHash(source)).Replace("-", string.Empty);
-        var ingressName = $"{ServiceName}-{InstanceId}-ingress-{hash}".ToLower();
-        return ingressName.Length <= IngressNameMaxLength ? ingressName : ingressName.Substring(0, IngressNameMaxLength);
+        var hash = BitConverter.ToString(SHA1.Create().ComputeHash(source)).Replace("-", string.Empty).ToLower();
+        var remainingLength = IngressNameMaxLength - hash.Length;
+        var prefix = $"{ServiceName}-{InstanceId}";
+        return prefix.Length <= remainingLength - 1? $"{prefix}-{hash}" : $"{prefix.Substring(0, remainingLength)}-{hash}";
     }
 
     public override string ToString()

--- a/ingress-supervisor/Models/TenantConfig.cs
+++ b/ingress-supervisor/Models/TenantConfig.cs
@@ -7,6 +7,7 @@ namespace ingress_supervisor.Models;
 
 public class TenantConfig
 {
+    private const int IngressNameMaxLength = 253;
     public string ServiceName { get; set; }
 
     public string InstanceId { get; set; }
@@ -21,10 +22,9 @@ public class TenantConfig
     public string GetIngressName()
     {
         var source = Encoding.ASCII.GetBytes($"{ServiceName}{InstanceId}{HostName}{Port}{Path}");
-        var hash = SHA256.Create().ComputeHash(source);
-        return $"{ServiceName}-{InstanceId}-ingress-{BitConverter.ToString(hash).Replace("-", string.Empty)}"
-            .Substring(0, 253)
-            .ToLower();
+        var hash = BitConverter.ToString(SHA256.Create().ComputeHash(source)).Replace("-", string.Empty);
+        var ingressName = $"{ServiceName}-{InstanceId}-ingress-{hash}".ToLower();
+        return ingressName.Length <= IngressNameMaxLength ? ingressName : ingressName.Substring(0, IngressNameMaxLength);
     }
 
     public override string ToString()

--- a/ingress-supervisor/Models/TenantConfig.cs
+++ b/ingress-supervisor/Models/TenantConfig.cs
@@ -11,6 +11,7 @@ public class TenantConfig
 
     public string HostName { get; set; }
 
+    // TODO: Do we need to have port in config?
     public int Port { get; set; }
 
     public string Path { get; set; }

--- a/ingress-supervisor/Models/TenantConfig.cs
+++ b/ingress-supervisor/Models/TenantConfig.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using k8s.Models;
 
@@ -16,7 +18,14 @@ public class TenantConfig
 
     public string Path { get; set; }
 
-    public string GetIngressName() => $"{ServiceName}-{InstanceId}-ingress-{Guid.NewGuid().ToString("n").Substring(0, 8)}";
+    public string GetIngressName()
+    {
+        var source = Encoding.ASCII.GetBytes($"{ServiceName}{InstanceId}{HostName}{Port}{Path}");
+        var hash = SHA256.Create().ComputeHash(source);
+        return $"{ServiceName}-{InstanceId}-ingress-{BitConverter.ToString(hash).Replace("-", string.Empty)}"
+            .Substring(0, 63)
+            .ToLower();
+    }
 
     public override string ToString()
     {

--- a/ingress-supervisor/Models/TenantConfig.cs
+++ b/ingress-supervisor/Models/TenantConfig.cs
@@ -23,7 +23,7 @@ public class TenantConfig
         var source = Encoding.ASCII.GetBytes($"{ServiceName}{InstanceId}{HostName}{Port}{Path}");
         var hash = SHA256.Create().ComputeHash(source);
         return $"{ServiceName}-{InstanceId}-ingress-{BitConverter.ToString(hash).Replace("-", string.Empty)}"
-            .Substring(0, 63)
+            .Substring(0, 253)
             .ToLower();
     }
 

--- a/ingress-supervisor/ServiceWatcher.cs
+++ b/ingress-supervisor/ServiceWatcher.cs
@@ -62,7 +62,7 @@ public class ServiceWatcher : BackgroundService
                 case WatchEventType.Added:
                     foreach (var serviceConfig in serviceConfigs)
                     {
-                        if (!_logic.ServiceHasIngress(allIngresses, serviceConfig))
+                        if (!_logic.ServiceHasMatchingIngress(allIngresses, serviceConfig))
                         {
                             await _kubernetesWrapper.CreateIngress(serviceConfig);
                             _logger.LogInformation("Created ingress for service: {}", service.Metadata.Name);
@@ -72,7 +72,7 @@ public class ServiceWatcher : BackgroundService
                 case WatchEventType.Deleted:
                     foreach (var serviceConfig in serviceConfigs)
                     {
-                        if (_logic.ServiceHasIngress(allIngresses, serviceConfig))
+                        if (_logic.ServiceHasMatchingIngress(allIngresses, serviceConfig))
                         {
                             await _kubernetesWrapper.DeleteIngress(serviceConfig.GetIngressName());
                             _logger.LogInformation("Deleted ingress for service: {}", serviceConfig.ServiceName);

--- a/ingress-supervisor/ServiceWatcher.cs
+++ b/ingress-supervisor/ServiceWatcher.cs
@@ -44,13 +44,14 @@ public class ServiceWatcher : BackgroundService
         _logger.LogInformation("Starting to watch services");
         await foreach (var (type, service) in servicesListResp.WatchAsync<V1Service, V1ServiceList>())
         {
+
             _logger.LogInformation("Got Service Event of Type: {} for Service: {}", type, service.Metadata.Name);
             if (service.Metadata?.Annotations?.ContainsKey("squid") != true)
             {
                 _logger.LogInformation("Ignoring service {} due to missing squid annotation", service.Metadata.Name);
                 continue;
             }
-
+            // TODO: Check that configmap exists.
             var squidConfig = await _kubernetesWrapper.GetSquidConfig();
             var serviceConfigs = squidConfig
                 .Where(config => config.ServiceName.Equals(service.Metadata.Name))

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -65,7 +65,7 @@ sleep 5
 
 # Verify delete (triggered on service delete)
 curl localhost/customer-d -s -H "host: baloo.devies.com" | grep "404 Not Found"
-echo "GET baloo.devies.com/customer-a successfully returned 404 Not Found"
+echo "GET baloo.devies.com/customer-d successfully returned 404 Not Found"
 
 curl localhost/customer-b -s -H "host: bagheera.devies.com" | grep "404 Not Found"
 echo "GET baloo.devies.com/customer-b successfully returned 404 Not Found"

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -36,7 +36,7 @@ curl localhost/customer-b -s -H "host: baloo.devies.com" | grep "Instanceid: 888
 curl localhost/customer-c -s -H "host: baloo.devies.com" | grep "404 Not Found"
 curl localhost/customer-a -s -H "host: baloo.devies.com" -H "Instanceid: 1337" | grep --invert-match "Instanceid: 1337"
 
-# Update config with new service config
+# Extend configuration with new instance
 kubectl apply -f test-configmap-extended.yml
 sleep 5
 
@@ -50,14 +50,22 @@ sleep 5
 # Verify delete (triggered on config change)
 curl localhost/customer-c -s -H "host: mowgli.devies.com" | grep "404 Not Found"
 
+# Update existing configuration with new instanceId for kunda and new hostname for kundb.
+kubectl apply -f test-configmap-modified.yml
+sleep 5
+
+# Verify updates (triggered on config change)
+curl localhost/customer-d -s -H "host: baloo.devies.com" | grep "Instanceid: 666"
+curl localhost/customer-b -s -H "host: bagheera.devies.com" | grep "Instanceid: 888"
+
 # Uninstall whoami
 helm uninstall whoami
 kubectl wait --for=delete pod --selector=app.kubernetes.io/name=whoami --timeout=60s
 sleep 5
 
 # Verify delete (triggered on service delete)
-curl localhost/customer-a -s -H "host: baloo.devies.com" | grep "404 Not Found"
+curl localhost/customer-d -s -H "host: baloo.devies.com" | grep "404 Not Found"
 echo "GET baloo.devies.com/customer-a successfully returned 404 Not Found"
 
-curl localhost/customer-b -s -H "host: baloo.devies.com" | grep "404 Not Found"
+curl localhost/customer-b -s -H "host: bagheera.devies.com" | grep "404 Not Found"
 echo "GET baloo.devies.com/customer-b successfully returned 404 Not Found"

--- a/tests/test-configmap-modified.yml
+++ b/tests/test-configmap-modified.yml
@@ -1,0 +1,21 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubesquid
+data:
+  kunda: |
+    {
+      "serviceName": "whoami",
+      "instanceId": "666",
+      "hostName": "baloo.devies.com",
+      "port": 80,
+      "path": "/customer-d"
+    }
+  kundb: |
+    {
+      "serviceName": "whoami",
+      "instanceId": "888",
+      "hostName": "bagheera.devies.com",
+      "port": 80,
+      "path": "/customer-b"
+    }

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -86,7 +86,6 @@ public class LogicTests
         Assert.False(_logic.IngressHasMatchingServiceConfig(ingress, serviceConfigs));
     }
 
-
     private List<V1Ingress> CreateIngresses(string name, string instanceId, string host, string serviceName, int port, string path)
     {
         return new List<V1Ingress>()

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -10,6 +10,14 @@ public class LogicTests
     private Logic _logic = new Logic();
 
     [Fact]
+    public void ServiceHasMatchingIngress_Matching()
+    {
+        var serviceConfig = CreateServiceConfig("test-service", "666", "mowgli.devies.com", 80, "/customer-a");
+        var ingresses = CreateIngresses(serviceConfig.GetIngressName(), "666", "mowgli.devies.com", "test-service", 80, "/customer-a");
+        Assert.True(_logic.ServiceHasMatchingIngress(ingresses, serviceConfig));
+    }
+
+    [Fact]
     public void ServiceHasMatchingIngress_HostMismatch()
     {
         var serviceConfig = CreateServiceConfig("test-service", "666", "mowgli.devies.com", 80, "/customer-a");

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -10,6 +10,14 @@ public class LogicTests
     private Logic _logic = new Logic();
 
     [Fact]
+    public void ServiceHasMatchingIngress_HostMismatch()
+    {
+        var serviceConfig = CreateServiceConfig("test-service", "666", "mowgli.devies.com", 80, "/customer-a");
+        var ingresses = CreateIngresses(serviceConfig.GetIngressName(), "666", "baloo.devies.com", "test-service", 80, "/customer-a");
+        Assert.False(_logic.ServiceHasMatchingIngress(ingresses, serviceConfig));
+    }
+
+    [Fact]
     public void ServiceHasIngress_IngressExists()
     {
         var serviceConfig = CreateServiceConfig("test-service", "666", "baloo.devies.com", 80, "/customer-a");

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -34,6 +34,14 @@ public class LogicTests
     }
 
     [Fact]
+    public void ServiceHasMatchingIngress_InstanceIdMismatch()
+    {
+        var serviceConfig = CreateServiceConfig("test-service", "some-new-instance-id", "mowgli.devies.com", 80, "/customer-a");
+        var ingresses = CreateIngresses(serviceConfig.GetIngressName(), "666", "mowgli.devies.com", "test-service", 80, "/customer-a");
+        Assert.False(_logic.ServiceHasMatchingIngress(ingresses, serviceConfig));
+    }
+
+    [Fact]
     public void ServiceHasMatchingIngresses_NoIngressesExists()
     {
         var serviceConfig = CreateServiceConfig("test-service", "666", "baloo.devies.com", 80, "/customer-a");

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -34,18 +34,10 @@ public class LogicTests
     }
 
     [Fact]
-    public void ServiceHasIngress_IngressExists()
+    public void ServiceHasMatchingIngresses_NoIngressesExists()
     {
         var serviceConfig = CreateServiceConfig("test-service", "666", "baloo.devies.com", 80, "/customer-a");
-        var ingresses = CreateIngresses(serviceConfig.GetIngressName(), "666", "baloo.devies.com", "test-service", 80, "/customer-a");
-        Assert.True(_logic.ServiceHasIngress(ingresses, serviceConfig));
-    }
-
-    [Fact]
-    public void ServiceHasIngresses_NoIngressesExists()
-    {
-        var serviceConfig = CreateServiceConfig("test-service", "666", "baloo.devies.com", 80, "/customer-a");
-        Assert.False(_logic.ServiceHasIngress(new List<V1Ingress>(), serviceConfig));
+        Assert.False(_logic.ServiceHasMatchingIngress(new List<V1Ingress>(), serviceConfig));
     }
 
     [Fact]

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -78,6 +78,13 @@ public class LogicTests
         var serviceConfigs = new List<TenantConfig> { CreateServiceConfig("test-service", "666", "mowgli.devies.com", 80, "/customer-a") };
         Assert.False(_logic.IngressHasMatchingServiceConfig(ingress, serviceConfigs));
     }
+    [Fact]
+    public void IngressHasMatchingServiceConfig_InstanceIdMismatch()
+    {
+        var ingress = CreateIngresses("test-service-666-ingress", "999", "mowgli.devies.com", "test-service", 80, "/customer-a").First();
+        var serviceConfigs = new List<TenantConfig> { CreateServiceConfig("test-service", "666", "mowgli.devies.com", 80, "/customer-a") };
+        Assert.False(_logic.IngressHasMatchingServiceConfig(ingress, serviceConfigs));
+    }
 
 
     private List<V1Ingress> CreateIngresses(string name, string instanceId, string host, string serviceName, int port, string path)

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -71,6 +71,14 @@ public class LogicTests
         Assert.False(_logic.IngressHasMatchingServiceConfig(ingress, serviceConfigs));
     }
 
+    [Fact]
+    public void IngressHasMatchingServiceConfig_PathMismatch()
+    {
+        var ingress = CreateIngresses("test-service-666-ingress", "666", "mowgli.devies.com", "test-service", 80, "/some/other/path").First();
+        var serviceConfigs = new List<TenantConfig> { CreateServiceConfig("test-service", "666", "mowgli.devies.com", 80, "/customer-a") };
+        Assert.False(_logic.IngressHasMatchingServiceConfig(ingress, serviceConfigs));
+    }
+
 
     private List<V1Ingress> CreateIngresses(string name, string instanceId, string host, string serviceName, int port, string path)
     {

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -49,18 +49,26 @@ public class LogicTests
     }
 
     [Fact]
-    public void IngressHasServiceConfig_ServiceExist()
+    public void IngressHasMatchingServiceConfig_Matching()
     {
         var serviceConfig = CreateServiceConfig("test-service", "666", "baloo.devies.com", 80, "/customer-a");
         var ingresses = CreateIngresses(serviceConfig.GetIngressName(), "666", "baloo.devies.com", "test-service", 80, "/customer-a");
-        Assert.True(_logic.IngressHasServiceConfig(ingresses.First(), new List<TenantConfig> { serviceConfig }));
+        Assert.True(_logic.IngressHasMatchingServiceConfig(ingresses.First(), new List<TenantConfig> { serviceConfig }));
     }
 
     [Fact]
-    public void IngressHasServiceConfig_NoServiceExist()
+    public void IngressHasMatchingServiceConfig_NoServiceExist()
     {
         var ingresses = CreateIngresses("test-service-666-ingress", "666", "baloo.devies.com", "test-service", 80, "/customer-a");
-        Assert.False(_logic.IngressHasServiceConfig(ingresses.First(), new List<TenantConfig>()));
+        Assert.False(_logic.IngressHasMatchingServiceConfig(ingresses.First(), new List<TenantConfig>()));
+    }
+
+    [Fact]
+    public void IngressHasMatchingServiceConfig_HostMismatch()
+    {
+        var ingress = CreateIngresses("test-service-666-ingress", "666", "baloo.devies.com", "test-service", 80, "/customer-a").First();
+        var serviceConfigs = new List<TenantConfig> { CreateServiceConfig("test-service", "666", "mowgli.devies.com", 80, "/customer-a") };
+        Assert.False(_logic.IngressHasMatchingServiceConfig(ingress, serviceConfigs));
     }
 
 

--- a/unit-tests/TenantConfigTests.cs
+++ b/unit-tests/TenantConfigTests.cs
@@ -12,7 +12,7 @@ public class TenantConfigTests
         {
             HostName = "shere-khan.devies.com",
             Path = "/my-path",
-            InstanceId = Guid.NewGuid().ToString(),
+            InstanceId = "666",
             Port = 80,
             ServiceName = "some-backend-service"
         };
@@ -20,7 +20,7 @@ public class TenantConfigTests
         {
             HostName = "shere-khan.devies.com",
             Path = "/my-path",
-            InstanceId = tenantConfig.InstanceId,
+            InstanceId = "666",
             Port = 80,
             ServiceName = "some-backend-service"
         };
@@ -35,11 +35,27 @@ public class TenantConfigTests
         {
             HostName = "shere-khan.devies.com",
             Path = "/my-path",
-            InstanceId = Guid.NewGuid().ToString(),
+            InstanceId = "666",
             Port = 80,
             ServiceName = "some-backend-service"
         }.GetIngressName();
         Assert.Matches(new Regex(@"^[a-z0-9][a-z0-9\-\.]*[a-z0-9]$"), ingressName);
-        Assert.InRange(ingressName.Length, 1, 253);
+        Assert.InRange(ingressName.Length, 1, TenantConfig.IngressNameMaxLength);
+    }
+
+    [Fact]
+    public void TenantConfig_IngressNameShouldBeTruncatedButStillContainFullHash()
+    {
+        var veryLongServiceName = string.Concat(Enumerable.Repeat("some-backend-service", 13));
+        var ingressName = new TenantConfig()
+        {
+            HostName = "shere-khan.devies.com",
+            Path = "/my-path",
+            InstanceId = "666",
+            Port = 80,
+            ServiceName = veryLongServiceName
+        }.GetIngressName();
+        var expectedHash = "b538347bddfcb2adc74477f5fdd1be5479b692a6";
+        Assert.Contains(expectedHash, ingressName);
     }
 }

--- a/unit-tests/TenantConfigTests.cs
+++ b/unit-tests/TenantConfigTests.cs
@@ -1,0 +1,45 @@
+using System.Text.RegularExpressions;
+using ingress_supervisor.Models;
+
+namespace unit_tests;
+
+public class TenantConfigTests
+{
+    [Fact]
+    public void TenantConfig_IngressNameShouldBeDeterministic()
+    {
+        var tenantConfig = new TenantConfig
+        {
+            HostName = "shere-khan.devies.com",
+            Path = "/my-path",
+            InstanceId = Guid.NewGuid().ToString(),
+            Port = 80,
+            ServiceName = "some-backend-service"
+        };
+        var tenantConfigWithIdenticalValues = new TenantConfig
+        {
+            HostName = "shere-khan.devies.com",
+            Path = "/my-path",
+            InstanceId = tenantConfig.InstanceId,
+            Port = 80,
+            ServiceName = "some-backend-service"
+        };
+        Assert.NotSame(tenantConfig, tenantConfigWithIdenticalValues);
+        Assert.Equal(tenantConfig.GetIngressName(), tenantConfigWithIdenticalValues.GetIngressName());
+    }
+
+    [Fact] // See: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+    public void TenantConfig_IngressNameShouldBeAValidDnsSubdomainName()
+    {
+        var ingressName = new TenantConfig()
+        {
+            HostName = "shere-khan.devies.com",
+            Path = "/my-path",
+            InstanceId = Guid.NewGuid().ToString(),
+            Port = 80,
+            ServiceName = "some-backend-service"
+        }.GetIngressName();
+        Assert.Matches(new Regex(@"^[a-z0-9][a-z0-9\-\.]*[a-z0-9]$"), ingressName);
+        Assert.InRange(ingressName.Length, 1, 253);
+    }
+}


### PR DESCRIPTION
Add support for modify ingress. Actually implemented by creating a new one, and then deleting the old one.

Prior naming of ingress caused conflicts during creation (since an ingress with that name already exist - because we haven't deleted the old one yet).
Initially we attempted to include a random part in the ingress name to remedy this. However, this was problematic in `ServiceWatcher`, where we need to delete an ingress based on a TenantConfig. Therefore, I set the ingress name so that it includes a SHA1 hash of all relevant values instead.

While adding the hash to the name, I had problems with illegal characters in the ingress name. Therefore I added some unit tests for that as well. Turns out the issue for me was upper case characters :)