### PR TITLE
Lookup service port using k8s api

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ data:
       "serviceName": "<name-of-a-service-in-the-cluster>",
       "instanceId": "<id-to-pass-down-to-service>",
       "hostName": "<ingress-rule-host>",
-      "port": "<port-for-the-service>",
       "path": "<ingress-rule-path>"
     }
 ```

--- a/ingress-supervisor/KubernetesWrapper.cs
+++ b/ingress-supervisor/KubernetesWrapper.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
-using System.Text.Json;
 using ingress_supervisor.Models;
 using k8s;
+using k8s.Autorest;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
 
@@ -41,7 +41,7 @@ public class KubernetesWrapper
             var service = await _client.ReadNamespacedServiceAsync(tenantConfig.ServiceName, _targetNamespace);
             servicePort = service.Spec.Ports.First().Port;
         }
-        catch (Exception e)
+        catch (HttpOperationException e)
         {
             _logger.LogError("Failed to fetch port number for service {}, due to: {}", tenantConfig.ServiceName, e.Message);
             return;
@@ -112,7 +112,7 @@ public class KubernetesWrapper
             await _client.CreateNamespacedIngressAsync(ingress, _targetNamespace);
             _logger.LogInformation("Successfully created ingress: {}", ingress.Metadata.Name);
         }
-        catch (Exception e)
+        catch (HttpOperationException e)
         {
             _logger.LogError("Failed to create ingress {}, due to: {}", ingress.Metadata.Name, e.Message);
         }
@@ -126,7 +126,7 @@ public class KubernetesWrapper
             await _client.DeleteNamespacedIngressAsync(ingressName, _targetNamespace);
             _logger.LogInformation("Successfully deleted ingress: {}", ingressName);
         }
-        catch (Exception e)
+        catch (HttpOperationException e)
         {
             _logger.LogError("Failed to delete ingress {}, due to: {}", ingressName, e.Message);
         }

--- a/ingress-supervisor/KubernetesWrapper.cs
+++ b/ingress-supervisor/KubernetesWrapper.cs
@@ -35,6 +35,18 @@ public class KubernetesWrapper
 
     public async Task CreateIngress(TenantConfig tenantConfig)
     {
+        int servicePort = 0;
+        try
+        {
+            var service = await _client.ReadNamespacedServiceAsync(tenantConfig.ServiceName, _targetNamespace);
+            servicePort = service.Spec.Ports.First().Port;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Failed to fetch port number for service {}, due to: {}", tenantConfig.ServiceName, e.Message);
+            return;
+        }
+
         var ingress = new V1Ingress()
         {
             Kind = "Ingress",
@@ -83,7 +95,7 @@ public class KubernetesWrapper
                                         Name = tenantConfig.ServiceName,
                                         Port = new V1ServiceBackendPort()
                                         {
-                                            Number = tenantConfig.Port
+                                            Number = servicePort
                                         }
                                     }
                                 }

--- a/ingress-supervisor/Models/TenantConfig.cs
+++ b/ingress-supervisor/Models/TenantConfig.cs
@@ -14,14 +14,11 @@ public class TenantConfig
 
     public string HostName { get; set; }
 
-    // TODO: Do we need to have port in config?
-    public int Port { get; set; }
-
     public string Path { get; set; }
 
     public string GetIngressName()
     {
-        var source = Encoding.ASCII.GetBytes($"{ServiceName}{InstanceId}{HostName}{Port}{Path}");
+        var source = Encoding.ASCII.GetBytes($"{ServiceName}{InstanceId}{HostName}{Path}");
         var hash = BitConverter.ToString(SHA1.Create().ComputeHash(source)).Replace("-", string.Empty).ToLower();
         var remainingLength = IngressNameMaxLength - hash.Length;
         var prefix = $"{ServiceName}-{InstanceId}";
@@ -30,7 +27,7 @@ public class TenantConfig
 
     public override string ToString()
     {
-        return $"ServiceName: {ServiceName}, InstanceId: {InstanceId}, HostName: {HostName}, Port: {Port}, Path: {Path}";
+        return $"ServiceName: {ServiceName}, InstanceId: {InstanceId}, HostName: {HostName}, Path: {Path}";
     }
 
     // TODO: Handle when deserialize not possible

--- a/ingress-supervisor/kubesquid-ingress-supervisor/templates/role.yaml
+++ b/ingress-supervisor/kubesquid-ingress-supervisor/templates/role.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["services"]
-    verbs: ["watch"]
+    verbs: ["watch", "get"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ingress-supervisor/kubesquid-ingress-supervisor/templates/role.yaml
+++ b/ingress-supervisor/kubesquid-ingress-supervisor/templates/role.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: watch-services
+  name: read-services
   namespace: default
 rules:
   - apiGroups: ["*"]
@@ -11,7 +11,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: watch-config-map
+  name: read-kubesquid-configmap
   namespace: default
 rules:
   - apiGroups: ["*"]

--- a/ingress-supervisor/kubesquid-ingress-supervisor/templates/rolebinding.yaml
+++ b/ingress-supervisor/kubesquid-ingress-supervisor/templates/rolebinding.yaml
@@ -1,12 +1,12 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: watch-services-binding
+  name: read-services-binding
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: watch-services
+  name: read-services
 subjects:
   - kind: ServiceAccount
     namespace: default
@@ -15,12 +15,12 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: watch-config-map-binding
+  name: read-kubesquid-configmap-binding
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: watch-config-map
+  name: read-kubesquid-configmap
 subjects:
   - kind: ServiceAccount
     namespace: default

--- a/tests/test-configmap-extended.yml
+++ b/tests/test-configmap-extended.yml
@@ -8,7 +8,6 @@ data:
       "serviceName": "whoami",
       "instanceId": "666",
       "hostName": "baloo.devies.com",
-      "port": 80,
       "path": "/customer-a"
     }
   kundb: |
@@ -16,7 +15,6 @@ data:
       "serviceName": "whoami",
       "instanceId": "888",
       "hostName": "baloo.devies.com",
-      "port": 80,
       "path": "/customer-b"
     }
   kundc: |
@@ -24,6 +22,5 @@ data:
       "serviceName": "whoami",
       "instanceId": "999",
       "hostName": "mowgli.devies.com",
-      "port": 80,
       "path": "/customer-c"
     }

--- a/tests/test-configmap-modified.yml
+++ b/tests/test-configmap-modified.yml
@@ -8,7 +8,6 @@ data:
       "serviceName": "whoami",
       "instanceId": "666",
       "hostName": "baloo.devies.com",
-      "port": 80,
       "path": "/customer-d"
     }
   kundb: |
@@ -16,6 +15,5 @@ data:
       "serviceName": "whoami",
       "instanceId": "888",
       "hostName": "bagheera.devies.com",
-      "port": 80,
       "path": "/customer-b"
     }

--- a/tests/test-configmap.yml
+++ b/tests/test-configmap.yml
@@ -8,7 +8,6 @@ data:
       "serviceName": "whoami",
       "instanceId": "666",
       "hostName": "baloo.devies.com",
-      "port": 80,
       "path": "/customer-a"
     }
   kundb: |
@@ -16,6 +15,5 @@ data:
       "serviceName": "whoami",
       "instanceId": "888",
       "hostName": "baloo.devies.com",
-      "port": 80,
       "path": "/customer-b"
     }

--- a/unit-tests/LogicTests.cs
+++ b/unit-tests/LogicTests.cs
@@ -102,7 +102,6 @@ public class LogicTests
                         HostName = host,
                         InstanceId = instanceId,
                         Path = path,
-                        Port = port,
                         ServiceName = serviceName
                     }.GetIngressName(),
                     Labels = new Dictionary<string, string>()
@@ -164,7 +163,6 @@ public class LogicTests
             ServiceName = serviceName,
             InstanceId = instanceId,
             HostName = hostname,
-            Port = port,
             Path = path
         };
     }

--- a/unit-tests/TenantConfigTests.cs
+++ b/unit-tests/TenantConfigTests.cs
@@ -13,7 +13,6 @@ public class TenantConfigTests
             HostName = "shere-khan.devies.com",
             Path = "/my-path",
             InstanceId = "666",
-            Port = 80,
             ServiceName = "some-backend-service"
         };
         var tenantConfigWithIdenticalValues = new TenantConfig
@@ -21,7 +20,6 @@ public class TenantConfigTests
             HostName = "shere-khan.devies.com",
             Path = "/my-path",
             InstanceId = "666",
-            Port = 80,
             ServiceName = "some-backend-service"
         };
         Assert.NotSame(tenantConfig, tenantConfigWithIdenticalValues);
@@ -36,7 +34,6 @@ public class TenantConfigTests
             HostName = "shere-khan.devies.com",
             Path = "/my-path",
             InstanceId = "666",
-            Port = 80,
             ServiceName = "some-backend-service"
         }.GetIngressName();
         Assert.Matches(new Regex(@"^[a-z0-9][a-z0-9\-\.]*[a-z0-9]$"), ingressName);
@@ -52,10 +49,9 @@ public class TenantConfigTests
             HostName = "shere-khan.devies.com",
             Path = "/my-path",
             InstanceId = "666",
-            Port = 80,
             ServiceName = veryLongServiceName
         }.GetIngressName();
-        var expectedHash = "b538347bddfcb2adc74477f5fdd1be5479b692a6";
+        var expectedHash = "5fe6bf660bddab333bb56a2a1cda4946363bca0c";
         Assert.Contains(expectedHash, ingressName);
     }
 }


### PR DESCRIPTION
Remove the expected service port field from the configuration, it will now be collected using the k8s API. 

This change require kubesquid to have `get` access to services. 

Also, keep role names up-to-date.