### PR TITLE
Modify ingresses on service port change

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/setup-kubectl@v2.0
         with:
-            version: 1.23.7
+            version: 1.23.6
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: apt install kubectl=1.23.6-00
+      - run: sudo apt install kubectl=1.23.6-00
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,9 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/setup-kubectl@v2.0
-        with:
-            version: 1.23.6
+      - run: apt install kubectl=1.23.6-00
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,6 +70,9 @@ jobs:
         with:
           config: tests/cluster-config.yml
           cluster_name: kind
+          version: v0.14.0
+          kubectl_version: v1.24.1
+      - run: kubectl version
       - uses: actions/download-artifact@v3
         with:
           name: ${{ env.IMAGE_NAME }}.tar.gz

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,9 +58,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: azure/setup-kubectl@v2.0
-        with:
-            version: v1.23.6
+      - name: install kubectl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https ca-certificates curl
+          sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+          echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          sudo apt-get update
+          sudo apt-get install -y kubectl
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,7 +59,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: azure/setup-kubectl@v2.0
-      - run: curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
+        with:
+            version: 1.23.7
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,7 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt install kubectl=1.23.6-00
+      - uses: azure/setup-kubectl@v2.0
+        with:
+            version: v1.23.6
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,6 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: azure/setup-kubectl@v2.0
+        with:
+          version: '1.24.0'
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,14 +58,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: install kubectl
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y apt-transport-https ca-certificates curl
-          sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-          echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-          sudo apt-get update
-          sudo apt-get install -y kubectl
       - uses: helm/kind-action@deab45fc8df9de5090a604e8ec11778eea7170bd
         with:
           config: tests/cluster-config.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt-get update
           sudo apt-get install -y kubectl
-      - uses: helm/kind-action@v1.2.0
+      - uses: helm/kind-action@deab45f
         with:
           config: tests/cluster-config.yml
           cluster_name: kind

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt-get update
           sudo apt-get install -y kubectl
-      - uses: helm/kind-action@deab45f
+      - uses: helm/kind-action@deab45fc8df9de5090a604e8ec11778eea7170bd
         with:
           config: tests/cluster-config.yml
           cluster_name: kind

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,8 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: azure/setup-kubectl@v2.0
-        with:
-          version: '1.24.0'
+      - run: curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl
       - uses: helm/kind-action@v1.2.0
         with:
           config: tests/cluster-config.yml

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -58,6 +58,15 @@ sleep 5
 curl localhost/customer-d -s -H "host: baloo.devies.com" | grep "Instanceid: 666"
 curl localhost/customer-b -s -H "host: bagheera.devies.com" | grep "Instanceid: 888"
 
+# Update whoami service with new port
+helm upgrade --install -f whoami-values-modified.yml whoami cowboysysop/whoami
+kubectl wait --for=jsonpath='{spec.ports[0].port}=99' --timeout=30s --namespace default services/whoami
+sleep 5
+
+# Verify update (trigger on service change)
+curl localhost/customer-d -s -H "host: baloo.devies.com" | grep "Instanceid: 666"
+curl localhost/customer-b -s -H "host: bagheera.devies.com" | grep "Instanceid: 888"
+
 # Uninstall whoami
 helm uninstall whoami
 kubectl wait --for=delete pod --selector=app.kubernetes.io/name=whoami --timeout=60s

--- a/tests/whoami-values-modified.yml
+++ b/tests/whoami-values-modified.yml
@@ -1,0 +1,4 @@
+service:
+  annotations:
+    squid: "true"
+  port: 99


### PR DESCRIPTION
When the port of a service is changed, a modify event will be triggered. Delete old ingress and create a new one with the new port.

In our e2e test we now use the `-jsonpath` argument to `kubectl wait` which requires a later a version of kubectl than what is currently included in the `ubuntu-latest` image. Hence, we now set both kind version and kubectl_version with the `setup-kind` action. Note that the `kubectl_version` argument has not been released yet, therefore we use the current latest commit to main branch as version.